### PR TITLE
Fix paraview generation for model output paths with underscores

### DIFF
--- a/scripts/generate_paraview_state.py
+++ b/scripts/generate_paraview_state.py
@@ -59,7 +59,7 @@ def create_chart_view(ylabel, log_scale=False, left_max_range=1000):
 
     
 def get_sample_fnames(prefix, data_dir):
-    return sorted(glob.glob(data_dir + '/' + prefix + '*'), key=lambda s: int(s.split('_')[2].split('.')[0]))
+    return sorted(glob.glob(data_dir + '/' + prefix + '*'), key=lambda s: int(s.split('_')[-1].split('.')[0]))
 
 
 def display_data(prefix, data_dir, render_view, label, color_func, representation='Surface'):


### PR DESCRIPTION
In the event that the outputs of a simcov run were placed into a directory containing the `_` character, the paraview state generation script would fail to execute, and return the the following:
```
ValueError: invalid literal for int() with base 10: 'virus'
```
This PR resolves the forward aligned array index issue which causes incorrect splitting in paths containing one or more underscores by instead indexing from the end of the string to the final underscore, which correctly returns the sort order elements of the filenames for both normal paths, and those containing underscores. 